### PR TITLE
Potential fix for code scanning alert no. 8: Unused global variable

### DIFF
--- a/src/saluki/main.py
+++ b/src/saluki/main.py
@@ -10,7 +10,6 @@ logger = logging.getLogger("saluki")
 logging.basicConfig(level=logging.INFO)
 
 _LISTEN = "listen"
-_PRODUCE = "produce"
 _CONSUME = "consume"
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/ISISComputingGroup/saluki/security/code-scanning/8](https://github.com/ISISComputingGroup/saluki/security/code-scanning/8)

The best way to fix this problem is to remove the assignment to `_PRODUCE` on line 13, since it is not used anywhere in the code and its assignment has no side effects. This can be done by simply deleting the line that defines `_PRODUCE`. No other changes are required, as the variable is not referenced elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
