### PR TITLE
add requires-python to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 ]
 readme = {file = "README.md", content-type = "text/markdown"}
 license-files = ["LICENSE"]
+requires-python = ">=3.12"
 
 [project.scripts]
 saluki = "saluki.main:main"


### PR DESCRIPTION
setting as 3.12 as we dont test before that. may add a matrix to the CI. 