### PR TITLE
Add terse and key options

### DIFF
--- a/src/consume.rs
+++ b/src/consume.rs
@@ -7,6 +7,7 @@ use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
 use std::time::Duration;
 use uuid::Uuid;
 
+#[allow(clippy::too_many_arguments)]
 pub fn consume(
     topic: &BrokerAndTopic,
     partition: Option<i32>,
@@ -15,6 +16,8 @@ pub fn consume(
     offset: Option<i64>,
     last: Option<i64>,
     timestamp: Option<i64>,
+    key: bool,
+    terse: bool,
 ) {
     debug!(
         "Listening to topic: {} partition {:?} on broker {}:{}, filtering {}",
@@ -100,9 +103,22 @@ pub fn consume(
                             }
                             debug!("Message has no schema id, ignoring filter")
                         }
-
+                        print!("[partition={}", message.partition());
+                        if key {
+                            print!(" key={:?}", message.key().unwrap_or(b""));
+                        }
+                        print!("] ");
                         match deserialize_message(p) {
-                            Ok(d) => println!("{d:?}"),
+                            Ok(d) => {
+                                if terse {
+                                    let schema = get_schema_id(p)
+                                        .and_then(|s| str::from_utf8(s).ok())
+                                        .unwrap_or("invalid");
+                                    println!("{schema} ({} bytes)", p.len())
+                                } else {
+                                    println!("{d:?}")
+                                }
+                            }
                             Err(e) => error!("Failed to deserialize message: {e:?}"),
                         }
                     }

--- a/src/consume.rs
+++ b/src/consume.rs
@@ -9,55 +9,61 @@ use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
 use std::time::Duration;
 use uuid::Uuid;
 
+pub struct ConsumeConfig<'a> {
+    pub topic: &'a BrokerAndTopic,
+    pub partition: Option<i32>,
+    pub filter: &'a Option<String>,
+    pub num_messages: Option<i64>,
+    pub offset: Option<i64>,
+    pub last: Option<i64>,
+    pub timestamp: Option<i64>,
+    pub key: bool,
+    pub terse: bool,
+    pub kafka_config: Option<Vec<KafkaOption>>,
+}
+
 #[allow(clippy::too_many_arguments)]
-pub fn consume(
-    topic: &BrokerAndTopic,
-    partition: Option<i32>,
-    filter: &Option<String>,
-    num_messages: Option<i64>,
-    offset: Option<i64>,
-    last: Option<i64>,
-    timestamp: Option<i64>,
-    key: bool,
-    terse: bool,
-    kafka_config: Option<Vec<KafkaOption>>,
-) {
+pub fn consume(config: &ConsumeConfig) {
     debug!(
         "Listening to topic: {} partition {:?} on broker {}:{}, filtering {}",
-        topic.topic,
-        partition,
-        topic.host,
-        topic.port,
-        filter.as_deref().unwrap_or("none")
+        config.topic.topic,
+        config.partition,
+        config.topic.host,
+        config.topic.port,
+        config.filter.as_deref().unwrap_or("none")
     );
-    let mut config = ClientConfig::new();
-    config.set("group.id", Uuid::new_v4().to_string());
-    config.set("bootstrap.servers", topic.broker());
+    let mut client_config = ClientConfig::new();
+    client_config.set("group.id", Uuid::new_v4().to_string());
+    client_config.set("bootstrap.servers", config.topic.broker());
 
-    if let Some(kafka_options) = kafka_config {
+    if let Some(kafka_options) = &config.kafka_config {
         for option in kafka_options {
             println!(
                 "Setting Kafka config option {}={}",
                 option.key, option.value
             );
-            config.set(&option.key, &option.value);
+            client_config.set(&option.key, &option.value);
         }
     }
 
-    let consumer: BaseConsumer = config.create().expect("Base creation failed");
+    let consumer: BaseConsumer = client_config.create().expect("Base creation failed");
 
     let start: Option<Offset>;
 
     let (low_watermark, high_watermark) = consumer
-        .fetch_watermarks(&topic.topic, partition.unwrap_or(0), Duration::from_secs(1))
-        .unwrap_or_else(|_| panic!("Failed to get watermarks for topic {}", topic.topic));
+        .fetch_watermarks(
+            &config.topic.topic,
+            config.partition.unwrap_or(0),
+            Duration::from_secs(1),
+        )
+        .unwrap_or_else(|_| panic!("Failed to get watermarks for topic {}", config.topic.topic));
     let num_messages_on_topic = high_watermark - low_watermark;
 
-    if let Some(_timestamp) = timestamp {
+    if let Some(_timestamp) = config.timestamp {
         let mut tpl = TopicPartitionList::new();
         tpl.add_partition_offset(
-            &topic.topic,
-            partition.unwrap_or(0),
+            &config.topic.topic,
+            config.partition.unwrap_or(0),
             Offset::Offset(_timestamp),
         )
         .expect("Can't add partition to consumer with timestamp");
@@ -70,13 +76,13 @@ pub fn consume(
                 .expect("No topics found for timestamp")
                 .offset(),
         );
-    } else if let Some(_offset) = offset {
+    } else if let Some(_offset) = config.offset {
         assert!(
             _offset >= low_watermark && _offset <= high_watermark,
             "offset ({_offset:?}) must be between high ({high_watermark}) and low({low_watermark}) watermarks"
         );
         start = Some(Offset::Offset(_offset));
-    } else if let Some(last_num_messages) = last {
+    } else if let Some(last_num_messages) = config.last {
         assert!(
             last_num_messages <= num_messages_on_topic,
             "Cannot consume {last_num_messages:?} messages from a topic which only has {num_messages_on_topic} messages"
@@ -89,26 +95,26 @@ pub fn consume(
     if let Some(_start) = start {
         info!("Starting at {_start:?}");
         let mut tpl = TopicPartitionList::new();
-        tpl.add_partition_offset(&topic.topic, partition.unwrap_or(0), _start)
+        tpl.add_partition_offset(&config.topic.topic, config.partition.unwrap_or(0), _start)
             .unwrap_or_else(|_| panic!("Failed to set partition offset to {:?}", _start));
         consumer.assign(&tpl).expect("Failed to assign to topic");
     }
 
     consumer
-        .subscribe(&[&topic.topic])
-        .unwrap_or_else(|_| panic!("Failed to subscribe to topic {}", topic.topic));
+        .subscribe(&[&config.topic.topic])
+        .unwrap_or_else(|_| panic!("Failed to subscribe to topic {}", config.topic.topic));
 
     let mut counter = 0;
     for message in consumer.iter() {
         match message {
             Ok(message) => {
-                if partition.is_some() && Some(message.partition()) != partition {
+                if config.partition.is_some() && Some(message.partition()) != config.partition {
                     continue;
                 }
 
                 match message.payload() {
                     Some(p) => {
-                        if let Some(f) = filter {
+                        if let Some(f) = config.filter {
                             if let Some(schema_id) = get_schema_id(p)
                                 && schema_id != f.to_bytes()
                             {
@@ -117,13 +123,13 @@ pub fn consume(
                             debug!("Message has no schema id, ignoring filter")
                         }
                         print!("[partition={}", message.partition());
-                        if key {
+                        if config.key {
                             print!(" key={:?}", message.key().unwrap_or(b""));
                         }
                         print!("] ");
                         match deserialize_message(p) {
                             Ok(d) => {
-                                if terse {
+                                if config.terse {
                                     let schema = get_schema_id(p)
                                         .and_then(|s| str::from_utf8(s).ok())
                                         .unwrap_or("invalid");
@@ -147,7 +153,7 @@ pub fn consume(
             }
         }
         counter += 1;
-        if Some(counter) == num_messages || Some(counter) == last {
+        if Some(counter) == config.num_messages || Some(counter) == config.last {
             println!("Reached {} messages, exiting", counter);
             break;
         }

--- a/src/howl.rs
+++ b/src/howl.rs
@@ -5,6 +5,9 @@ use flatbuffers::FlatBufferBuilder;
 use isis_streaming_data_types::flatbuffers_generated::events_ev44::{
     Event44Message, Event44MessageArgs, finish_event_44_message_buffer,
 };
+use isis_streaming_data_types::flatbuffers_generated::pulse_metadata_pu00::{
+    Pu00Message, Pu00MessageArgs, finish_pu_00_message_buffer,
+};
 use isis_streaming_data_types::flatbuffers_generated::run_start_pl72::{
     RunStart, RunStartArgs, SpectraDetectorMapping, SpectraDetectorMappingArgs,
     finish_run_start_buffer,
@@ -126,6 +129,18 @@ fn produce_messages(
         .try_into()
         .expect("This will fail after April 11th, 2262");
 
+    match producer.send(
+        BaseRecord::to(conf.event_topic)
+            .key("")
+            .payload(generate_fake_metadata(fbb, now_nanos))
+            .timestamp(now_nanos / 1_000_000),
+    ) {
+        Ok(_) => {}
+        Err(err) => {
+            error!("Failed to send messages: {}", err.0);
+        }
+    }
+
     for _ in 0..conf.messages_per_frame {
         match producer.send(
             BaseRecord::to(conf.event_topic)
@@ -222,6 +237,21 @@ fn generate_fake_events<'a>(
     fbb.finished_data()
 }
 
+fn generate_fake_metadata<'a>(fbb: &'a mut FlatBufferBuilder<'_>, timestamp_ns: i64) -> &'a [u8] {
+    fbb.reset();
+    let args = Pu00MessageArgs {
+        reference_time: timestamp_ns,
+        message_id: 0,
+        source_name: Some(fbb.create_string("saluki")),
+        period_number: Some(1),
+        vetos: Some(0),
+        proton_charge: Some(0.1),
+    };
+    let pu00 = Pu00Message::create(fbb, &args);
+    finish_pu_00_message_buffer(fbb, pu00);
+    fbb.finished_data()
+}
+
 pub struct HowlConfig<'a> {
     pub broker: &'a str,
     pub event_topic: &'a str,
@@ -243,14 +273,18 @@ pub fn howl(conf: &HowlConfig) {
         .as_nanos()
         .try_into()
         .expect("This will fail after April 11th, 2262");
+
     let ev44_size =
         generate_fake_events(&mut fbb, &mut rng, 0, conf.event_message_config, now_nanos).len()
             as u32;
-
     debug!("ev44 size is {ev44_size} bytes");
 
-    // calculate rate
-    let rate_bytes_per_sec = ev44_size * conf.messages_per_frame * conf.frames_per_second;
+    let pu00_size = generate_fake_metadata(&mut fbb, now_nanos).len() as u32;
+    debug!("pu00 size is {pu00_size} bytes");
+
+    // calculate overall rate (with both ev44 and pu00)
+    let rate_bytes_per_sec = ev44_size * conf.messages_per_frame * conf.frames_per_second
+        + pu00_size * conf.frames_per_second;
     debug!("bytes per second: {rate_bytes_per_sec}");
 
     let rate_mbit_per_sec = (rate_bytes_per_sec as f64 / (1024. * 1024.)) * 8.0;
@@ -259,6 +293,7 @@ pub fn howl(conf: &HowlConfig) {
     println!(
         "Attempting to simulate data rate: {rate_mbit_per_sec:.3} Mbit/s ({rate_mebibits_per_sec:.3} MiB/s)"
     );
+    println!("Each pu00 is {pu00_size} bytes");
     println!("Each ev44 is {ev44_size} bytes");
 
     let producer: ThreadedProducer<DefaultProducerContext> = ClientConfig::new()
@@ -291,6 +326,7 @@ pub fn howl(conf: &HowlConfig) {
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("Failed to get system time");
     debug!("Target time: {target_time:?}");
+
     loop {
         target_time += target_frame_time;
         debug!("New target: {target_time:?}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,12 @@ enum Commands {
         /// Print last x messages on topic
         #[arg(short, long, conflicts_with_all = ["offset","timestamp","messages","filter"])]
         last: Option<i64>,
+        /// Show message key
+        #[arg(long, action=clap::ArgAction::SetTrue)]
+        key: bool,
+        /// Print using terse format (just schema ID and length)
+        #[arg(long, action=clap::ArgAction::SetTrue)]
+        terse: bool,
     },
     /// Print broker metadata.
     Sniff {
@@ -97,8 +103,10 @@ fn main() {
             offset,
             last,
             timestamp,
+            key,
+            terse,
         } => consume::consume(
-            &topic, partition, &filter, messages, offset, last, timestamp,
+            &topic, partition, &filter, messages, offset, last, timestamp, key, terse,
         ),
         Commands::Sniff { broker } => sniff(&broker),
         Commands::Howl {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod sniff;
 
 use crate::cli_utils::BrokerAndOptionalTopic;
 use crate::cli_utils::KafkaOption;
+use crate::consume::ConsumeConfig;
 use crate::count::count;
 use crate::howl::{EventMessageConfig, HowlConfig, howl};
 use crate::sniff::sniff;
@@ -135,18 +136,18 @@ async fn main() {
             key,
             terse,
             kafka_config,
-        } => consume::consume(
-            &topic,
+        } => consume::consume(&ConsumeConfig {
+            topic: &topic,
             partition,
-            &filter,
-            messages,
+            filter: &filter,
+            num_messages: messages,
             offset,
             last,
             timestamp,
             key,
             terse,
             kafka_config,
-        ),
+        }),
         Commands::Sniff {
             broker,
             kafka_config,


### PR DESCRIPTION
Should be merged after https://github.com/ISISComputingGroup/saluki/pull/63

Adds `--terse` format:

```
[partition=4] pu00 (96 bytes)
[partition=4] ev44 (16120 bytes)
[partition=6] pu00 (96 bytes)
[partition=6] ev44 (16120 bytes)
```

and `--key` option:

```
[partition=7 key=[0, 0, 0, 0, 0, 0, 8, 138]] pu00 (96 bytes)
[partition=7 key=[0, 0, 0, 0, 0, 0, 8, 138]] ev44 (16120 bytes)
[partition=1 key=[0, 0, 0, 0, 0, 0, 8, 139]] pu00 (96 bytes)
[partition=1 key=[0, 0, 0, 0, 0, 0, 8, 139]] ev44 (16120 bytes)
```